### PR TITLE
Add a rule to prevent passing methods as props to React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ eslint plugin with our set of custom rules for various things
 - [khan/flow-array-type-style](docs/flow-array-type-style.md)
 - [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
-- [khan/react-no-method-jsx-attribute](docs/react-no-subscriptions-before-mount.md)
+- [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ eslint plugin with our set of custom rules for various things
 - [khan/flow-array-type-style](docs/flow-array-type-style.md)
 - [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
+- [khan/react-no-method-jsx-attribute](docs/react-no-subscriptions-before-mount.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)

--- a/docs/react-no-method-jsx-attribute.md
+++ b/docs/react-no-method-jsx-attribute.md
@@ -66,3 +66,15 @@ class Foo extends React.Component {
     }
 }
 ```
+
+```js
+class Foo extends React.Component {
+    get bar() {
+        return this._bar;
+    }
+
+    render() {
+        return <div id={this.bar} />
+    }
+}
+```

--- a/docs/react-no-method-jsx-attribute.md
+++ b/docs/react-no-method-jsx-attribute.md
@@ -1,0 +1,68 @@
+# Prevent passing methods as props to other components (react-no-method-jsx-attribute)
+
+Passing methods as props without pre-binding is a common mistake in React programming.  
+Components created using `createReactClass` avoid this issue because `createReactClass`
+pre-binds all non-lifecycle methods.
+
+This eslint rule warns against passing methods as props to other components and suggests
+using class properties instead.  This ensure that `this` is correct when the component 
+receiving the props calls it.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+class Foo extends React.Component {
+    handleClick() {}
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    handleBaz() {}
+    
+    render() {
+        return <Bar onBaz={this.handleBaz}>
+    }
+}
+```
+
+The following are not considered warnings:
+
+```js
+class Foo extends React.Component {
+    handleClick = () => {}
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    handleClick() {}
+    
+    render() {
+        return <div onClick={() => this.handleClick()}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleClick = () => {};
+    }
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ module.exports = {
         "flow-array-type-style": require("./rules/flow-array-type-style.js"),
         "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
+        "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
     },
 };

--- a/lib/rules/react-no-method-jsx-attribute.js
+++ b/lib/rules/react-no-method-jsx-attribute.js
@@ -1,0 +1,66 @@
+module.exports = {
+    meta: {
+        docs: {
+            description: "Ensure that methods aren't used as jsx attributes",
+            category: "react",
+            recommended: false,
+        },
+        schema: [],
+    },
+
+    create(context) {
+        const methods = new Set();
+        const classProperties = new Set();
+
+        return {
+            ClassDeclaration(node) {
+                for (const child of node.body.body) {
+                    if (child.type === "ClassProperty") {
+                        if (child.key.type === "Identifier") {
+                            classProperties.add(child.key.name);
+                        }
+                    } else if (child.type === "MethodDefinition") {
+                        if (child.key.type === "Identifier") {
+                            methods.add(child.key.name);
+                        }
+                    }
+                }
+            },
+            "ClassDeclaration:exit"(node) {
+                for (const child of node.body.body) {
+                    if (child.type === "ClassProperty") {
+                        if (child.key.type === "Identifier") {
+                            classProperties.delete(child.key.name);
+                        }
+                    } else if (child.type === "MethodDefinition") {
+                        if (child.key.type === "Identifier") {
+                            methods.delete(child.key.name);
+                        }
+                    }
+                }
+            },
+            JSXAttribute(node) {
+                const {value} = node;
+                if (value.type === "JSXExpressionContainer") {
+                    const {expression} = node.value;
+                    if (expression.type === "MemberExpression") {
+                        const {object, property} = expression;
+                        if (
+                            object.type === "ThisExpression" &&
+                            property.type === "Identifier"
+                        ) {
+                            const {name} = property;
+                            if (methods.has(name)) {
+                                context.report({
+                                    node: node,
+                                    message:
+                                        "Methods cannot be passed as props, use a class property instead.",
+                                });
+                            }
+                        }
+                    }
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/react-no-method-jsx-attribute.js
+++ b/lib/rules/react-no-method-jsx-attribute.js
@@ -15,33 +15,40 @@ module.exports = {
         return {
             ClassDeclaration(node) {
                 for (const child of node.body.body) {
-                    if (child.type === "ClassProperty") {
-                        if (child.key.type === "Identifier") {
-                            classProperties.add(child.key.name);
-                        }
-                    } else if (child.type === "MethodDefinition") {
-                        if (child.key.type === "Identifier") {
-                            methods.add(child.key.name);
-                        }
+                    if (
+                        child.type === "ClassProperty" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        classProperties.add(child.key.name);
+                    } else if (
+                        child.type === "MethodDefinition" &&
+                        child.kind === "method" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        methods.add(child.key.name);
                     }
                 }
             },
             "ClassDeclaration:exit"(node) {
                 for (const child of node.body.body) {
-                    if (child.type === "ClassProperty") {
-                        if (child.key.type === "Identifier") {
-                            classProperties.delete(child.key.name);
-                        }
-                    } else if (child.type === "MethodDefinition") {
-                        if (child.key.type === "Identifier") {
-                            methods.delete(child.key.name);
-                        }
+                    if (
+                        child.type === "ClassProperty" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        classProperties.delete(child.key.name);
+                    } else if (
+                        child.type === "MethodDefinition" &&
+                        child.kind === "method" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        methods.delete(child.key.name);
                     }
                 }
             },
             JSXAttribute(node) {
                 const {value} = node;
-                if (value.type === "JSXExpressionContainer") {
+                // value doesn't exist for boolean shorthand attributes
+                if (value && value.type === "JSXExpressionContainer") {
                     const {expression} = node.value;
                     if (expression.type === "MemberExpression") {
                         const {object, property} = expression;

--- a/test/react-no-method-jsx-attribute_test.js
+++ b/test/react-no-method-jsx-attribute_test.js
@@ -66,7 +66,7 @@ class Foo {
     }
 
     render() {
-        return <div onClick={this.bar} />
+        return <div id={this.bar} />
     }
 }`,
             options: [],

--- a/test/react-no-method-jsx-attribute_test.js
+++ b/test/react-no-method-jsx-attribute_test.js
@@ -1,0 +1,97 @@
+const path = require("path");
+
+const rule = require("../lib/index.js").rules["react-no-method-jsx-attribute"];
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+
+ruleTester.run("react-no-method-jsx-attribute", rule, {
+    valid: [
+        {
+            code: `
+class Foo {
+    constructor() {
+        this.handleClick = () => {};
+    }
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+        },
+        {
+            code: `
+class Foo {
+    handleClick = () => {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+        },
+        {
+            code: `
+class Foo {
+    handleClick = () => {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}
+
+class Bar {
+    handleClick() {}
+
+    render() {
+        return <div onClick={() => this.handleClick()} />
+    }
+}`,
+            options: [],
+        },
+    ],
+    invalid: [
+        {
+            code: `
+class Foo {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+            errors: [
+                "Methods cannot be passed as props, use a class property instead.",
+            ],
+        },
+        {
+            code: `
+class Foo {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}
+
+class Bar {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+            errors: [
+                "Methods cannot be passed as props, use a class property instead.",
+                "Methods cannot be passed as props, use a class property instead.",
+            ],
+        },
+    ],
+});

--- a/test/react-no-method-jsx-attribute_test.js
+++ b/test/react-no-method-jsx-attribute_test.js
@@ -11,6 +11,7 @@ const ruleTester = new RuleTester(parserOptions);
 
 ruleTester.run("react-no-method-jsx-attribute", rule, {
     valid: [
+        // method arrow function in constructor
         {
             code: `
 class Foo {
@@ -24,6 +25,7 @@ class Foo {
 }`,
             options: [],
         },
+        // method arrow function class property
         {
             code: `
 class Foo {
@@ -35,6 +37,7 @@ class Foo {
 }`,
             options: [],
         },
+        // different classes using the same event handler
         {
             code: `
 class Foo {
@@ -54,8 +57,23 @@ class Bar {
 }`,
             options: [],
         },
+        // getter method - called in Foo's scope so it's fine
+        {
+            code: `
+class Foo {
+    get bar() {
+        return this._bar;
+    }
+
+    render() {
+        return <div onClick={this.bar} />
+    }
+}`,
+            options: [],
+        },
     ],
     invalid: [
+        // regular method, not okay
         {
             code: `
 class Foo {
@@ -70,6 +88,7 @@ class Foo {
                 "Methods cannot be passed as props, use a class property instead.",
             ],
         },
+        // two regular methods, both not okay, two errors
         {
             code: `
 class Foo {


### PR DESCRIPTION
This should come in handy as we convert more createReactClass components to using ES6 style classes.