### PR TITLE
Add flow-exact-props rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ eslint plugin with our set of custom rules for various things
 ## Rules
 
 - [khan/flow-array-type-style](docs/flow-array-type-style.md)
+- [khan/flow-exact-props](docs/flow-exact-props.md)
 - [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
 - [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)

--- a/docs/flow-exact-props.md
+++ b/docs/flow-exact-props.md
@@ -1,0 +1,41 @@
+# Require exact object types for Props (flow-exact-props)
+
+Using exact object types for Props can help identify extra props and in
+the case of optional props, typos.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+type Props = { x: number };
+class Foo extends React.Component<Props> {}
+```
+
+```js
+type FooProps = { x: number };
+class Foo extends React.Component<FooProps> {}
+```
+
+```js
+type Props = { x: number };
+const Foo = (props: Props) => {}
+```
+
+The following are not considered warnings:
+
+```js
+type Props = {| x: number |};
+class Foo extends React.Component<Props> {}
+```
+
+```js
+type BarProps = { x: number };
+type FooProps = {| x: number |};
+class Foo extends React.Component<FooProps> {}
+```
+
+```js
+type Props = {| x: number |};
+const Foo = (props: Props) => {}
+```

--- a/docs/flow-exact-props.md
+++ b/docs/flow-exact-props.md
@@ -3,6 +3,9 @@
 Using exact object types for Props can help identify extra props and in
 the case of optional props, typos.
 
+This rule supports autofixing.  Please note, this may result in new flow
+errors.
+
 ## Rule Details
 
 The following are considered warnings:

--- a/lib/rules/flow-exact-props.js
+++ b/lib/rules/flow-exact-props.js
@@ -1,0 +1,98 @@
+const t = require("@babel/types");
+
+const isReactClassComponent = node => {
+    if (t.isClassDeclaration(node)) {
+        const {superClass} = node;
+        if (t.isMemberExpression(superClass)) {
+            const {object, property} = superClass;
+            if (
+                t.isIdentifier(object, {name: "React"}) &&
+                t.isIdentifier(property, {name: "Component"})
+            ) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+const isReactFunctionalComponent = node => {
+    if (t.isArrowFunctionExpression(node)) {
+        if (
+            node.params.length === 1 &&
+            t.isIdentifier(node.params[0], {name: "props"})
+        ) {
+            return true;
+        }
+    }
+};
+
+const maybeReport = (node, props, typeAliases, context) => {
+    if (t.isGenericTypeAnnotation(props)) {
+        const {name} = props.id;
+        const alias = typeAliases.get(name);
+        if (alias && !alias.right.exact) {
+            const sourceCode = context.getSource();
+            context.report({
+                fix(fixer) {
+                    const right = alias.right;
+                    const rightText = sourceCode.slice(
+                        right.range[0] + 1,
+                        right.range[1] - 1,
+                    );
+                    const replacementText = `{|${rightText}|}`;
+
+                    return fixer.replaceText(alias.right, replacementText);
+                },
+                node: node,
+                message: `"${name}" type should be exact`,
+            });
+        }
+    }
+};
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Prefer exact object type for react props",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const typeAliases = new Map();
+
+        return {
+            TypeAlias(node) {
+                const ancestors = context.getAncestors();
+                if (
+                    t.isProgram(node.parent) &&
+                    t.isObjectTypeAnnotation(node.right)
+                ) {
+                    typeAliases.set(node.id.name, node);
+                }
+            },
+            ClassDeclaration(node) {
+                if (isReactClassComponent(node)) {
+                    const {superTypeParameters} = node;
+                    if (t.isTypeParameterInstantiation(superTypeParameters)) {
+                        const props = superTypeParameters.params[0];
+                        maybeReport(node, props, typeAliases, context);
+                    }
+                }
+            },
+            ArrowFunctionExpression(node) {
+                if (isReactFunctionalComponent(node)) {
+                    const {typeAnnotation} = node.params[0];
+                    if (t.isTypeAnnotation(typeAnnotation)) {
+                        const props = typeAnnotation.typeAnnotation;
+                        maybeReport(node, props, typeAliases, context);
+                    }
+                }
+            },
+        };
+    },
+};

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "test": "mocha test/**/*.js",
     "prettier": "prettier --write '{lib,test}/**/*.js'",
     "prepublish": "npm run test && npm run prettier"
+  },
+  "dependencies": {
+    "@babel/types": "^7.7.4"
   }
 }

--- a/test/flow-exact-props_test.js
+++ b/test/flow-exact-props_test.js
@@ -1,0 +1,76 @@
+const rule = require("../lib/rules/flow-exact-props");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-exact-props", rule, {
+    valid: [
+        {
+            code: `
+        type Props = {| x: number |};
+        class Foo extends React.Component<Props> {}`,
+        },
+        {
+            code: `
+        type BarProps = { x: number };
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}`,
+        },
+        {
+            code: `
+        type Props = {| x: number |};
+        const Foo = (props: Props) => {}`,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+        type Props = { x: number };
+        class Foo extends React.Component<Props> {}`,
+            errors: ['"Props" type should be exact'],
+            output: `
+        type Props = {| x: number |};
+        class Foo extends React.Component<Props> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        class Foo extends React.Component<FooProps> {}`,
+            errors: ['"FooProps" type should be exact'],
+            output: `
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        class Foo extends React.Component<FooProps> {}
+        type BarProps = { x: number };
+        class Bar extends React.Component<BarProps> {}`,
+            errors: [
+                '"FooProps" type should be exact',
+                '"BarProps" type should be exact',
+            ],
+            output: `
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}
+        type BarProps = {| x: number |};
+        class Bar extends React.Component<BarProps> {}`,
+        },
+        {
+            code: `
+type Props = { x: number };
+const Foo = (props: Props) => {}`,
+            errors: ['"Props" type should be exact'],
+            output: `
+type Props = {| x: number |};
+const Foo = (props: Props) => {}`,
+        },
+    ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
+  integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 acorn-jsx@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"


### PR DESCRIPTION
This rule requires that we the explicit exact type notation for flow type props.  Although flow has recently added an option to require explicit exactness on all object types, making that change would be quite disruptive because there are many more object types than just those used for props.  This rule will allow us to encourage people to make all props exact moving forward.

I'd like to do the same for state, but will add a separate rule for that.  This will allow us to adopt these new rules incrementally and will make it easier to provide more precise feedback messages.

This rule has an autofix option which will make upgrading existing violations easier.