### PR TITLE
Report errors where the type or method is defined

### DIFF
--- a/lib/rules/flow-exact-props.js
+++ b/lib/rules/flow-exact-props.js
@@ -22,7 +22,7 @@ const maybeReport = (node, typeAnnotation, typeAliases, context) => {
 
                     return fixer.replaceText(alias.right, replacementText);
                 },
-                node: node,
+                node: alias,
                 message: `"${name}" type should be exact`,
             });
         }

--- a/lib/rules/flow-exact-state.js
+++ b/lib/rules/flow-exact-state.js
@@ -19,7 +19,7 @@ const maybeReport = (node, typeAnnotation, typeAliases, context) => {
 
                     return fixer.replaceText(alias.right, replacementText);
                 },
-                node: node,
+                node: alias,
                 message: `"${name}" type should be exact`,
             });
         }

--- a/lib/rules/react-no-method-jsx-attribute.js
+++ b/lib/rules/react-no-method-jsx-attribute.js
@@ -9,8 +9,8 @@ module.exports = {
     },
 
     create(context) {
-        const methods = new Set();
-        const classProperties = new Set();
+        const methods = new Map();
+        const classProperties = new Map();
 
         return {
             ClassDeclaration(node) {
@@ -19,13 +19,13 @@ module.exports = {
                         child.type === "ClassProperty" &&
                         child.key.type === "Identifier"
                     ) {
-                        classProperties.add(child.key.name);
+                        classProperties.set(child.key.name, child);
                     } else if (
                         child.type === "MethodDefinition" &&
                         child.kind === "method" &&
                         child.key.type === "Identifier"
                     ) {
-                        methods.add(child.key.name);
+                        methods.set(child.key.name, child);
                     }
                 }
             },
@@ -59,7 +59,7 @@ module.exports = {
                             const {name} = property;
                             if (methods.has(name)) {
                                 context.report({
-                                    node: node,
+                                    node: methods.get(name),
                                     message:
                                         "Methods cannot be passed as props, use a class property instead.",
                                 });


### PR DESCRIPTION
Before this change we were reporting where a type or method was used.  In the case of `Props` and `State` this meant the whole component was flagged by eslint.  In the case of methods being passed to JSX attributes this mean that the attribute was being flagged instead of the method itself.  The PR instead has the rule flags the definition which is where these errors need to be corrected anyways.

I tested this change by doing the following:
- yarn link (in eslint-plugin-khan)
- yarn link "@khanacademy/eslint-plugin" (in khan-linter)
- re-opened `webapp` in VSCode and saw a couple of different errors showing up in the right places.

<img width="1093" alt="Screen Shot 2019-11-27 at 3 53 41 PM" src="https://user-images.githubusercontent.com/1044413/69758683-2bd88780-112e-11ea-812e-f054e4b195f9.png">

<img width="635" alt="Screen Shot 2019-11-27 at 3 54 07 PM" src="https://user-images.githubusercontent.com/1044413/69758686-2e3ae180-112e-11ea-9240-28d263dff745.png">

