### PR TITLE
Add rule to check number of decimal places in svg paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ eslint plugin with our set of custom rules for various things
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
 - [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)
+- [khan/react-svg-path-repcision](docs/react-svg-path-precision.md)

--- a/docs/react-svg-path-precision.md
+++ b/docs/react-svg-path-precision.md
@@ -1,0 +1,23 @@
+# Disallow SVG paths with too many decimal places (react-svg-path-precision)
+
+SVG paths exported form asset creation tools often use too many decimal places
+than are necessary especially for content where the viewbox is the same size
+as the SVG element.
+
+This rule can detect and fix paths with too many decimal places.  The rule
+defaults to two decimal places of precision.  This can be changed by passing
+an object, e.g. `{precision: 3}`, as an option in your eslint configuration.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+<path d="M1.23,0.45L-0.98,42Z"/>
+```
+
+The following are not considered warnings:
+
+```js
+<path d="M1.234,0.456L-0.987,42Z"/>
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,5 +7,6 @@ module.exports = {
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
         "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
+        "react-svg-path-precision": require("./rules/react-svg-path-precision.js"),
     },
 };

--- a/lib/rules/react-svg-path-precision.js
+++ b/lib/rules/react-svg-path-precision.js
@@ -40,7 +40,6 @@ module.exports = {
                     if (t.isJSXOpeningElement(node.parent) && t.isJSXIdentifier(node.parent.name, {name: "path"})) {
                         const d = node.value.value;
 
-                        
                         if (regex.test(d)) {
                             context.report({
                                 fix(fixer) {
@@ -53,7 +52,6 @@ module.exports = {
                                     "This path contains numbers with too many decimal places.",
                             });
                         }
-
                     }
                 }
             },

--- a/lib/rules/react-svg-path-precision.js
+++ b/lib/rules/react-svg-path-precision.js
@@ -30,7 +30,7 @@ module.exports = {
                 }
             }
         }
-        const pattern = `(\\.${"[0-9]".repeat(precision)})[0-9]+`;
+        const pattern = `\\d*\\.${"\\d+".repeat(precision)}\\d+`;
         const regex = new RegExp(pattern, "g");
 
         return {
@@ -43,7 +43,10 @@ module.exports = {
                         if (regex.test(d)) {
                             context.report({
                                 fix(fixer) {
-                                    const replacementText = d.replace(regex, (subtring, group) => group);
+                                    const replacementText = d.replace(
+                                        regex, 
+                                        (match) => parseFloat(match).toFixed(precision),
+                                    );
         
                                     return fixer.replaceText(node.value, replacementText);
                                 },

--- a/lib/rules/react-svg-path-precision.js
+++ b/lib/rules/react-svg-path-precision.js
@@ -30,7 +30,7 @@ module.exports = {
                 }
             }
         }
-        const pattern = `(\.${"[0-9]".repeat(precision)})[0-9]+`;
+        const pattern = `(\\.${"[0-9]".repeat(precision)})[0-9]+`;
         const regex = new RegExp(pattern, "g");
 
         return {

--- a/lib/rules/react-svg-path-precision.js
+++ b/lib/rules/react-svg-path-precision.js
@@ -26,11 +26,11 @@ module.exports = {
         for (const option of context.options) {
             if (typeof option === "object") {
                 if (option.hasOwnProperty("precision")) {
-                    precision = option.precision;
+                    precision = Math.max(option.precision, 0);
                 }
             }
         }
-        const pattern = `\\d*\\.${"\\d+".repeat(precision)}\\d+`;
+        const pattern = `\\d*\\.\\d{${precision},}\\d+`;
         const regex = new RegExp(pattern, "g");
 
         return {

--- a/lib/rules/react-svg-path-precision.js
+++ b/lib/rules/react-svg-path-precision.js
@@ -1,0 +1,62 @@
+const t = require("@babel/types");
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Ensure that SVG paths don't use too many decimal places",
+            category: "react",
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    precision: {
+                        type: "number"
+                    }
+                },
+                additionalProperties: false
+            },
+        ],
+    },
+
+    create(context) {
+        let precision = 2;
+        for (const option of context.options) {
+            if (typeof option === "object") {
+                if (option.hasOwnProperty("precision")) {
+                    precision = option.precision;
+                }
+            }
+        }
+        const pattern = `(\.${"[0-9]".repeat(precision)})[0-9]+`;
+        const regex = new RegExp(pattern, "g");
+
+        return {
+            
+            JSXAttribute(node) {
+                if (t.isJSXAttribute(node) && t.isJSXIdentifier(node.name, {name: "d"})) {
+                    if (t.isJSXOpeningElement(node.parent) && t.isJSXIdentifier(node.parent.name, {name: "path"})) {
+                        const d = node.value.value;
+
+                        
+                        if (regex.test(d)) {
+                            context.report({
+                                fix(fixer) {
+                                    const replacementText = d.replace(regex, (subtring, group) => group);
+        
+                                    return fixer.replaceText(node.value, replacementText);
+                                },
+                                node,
+                                message:
+                                    "This path contains numbers with too many decimal places.",
+                            });
+                        }
+
+                    }
+                }
+            },
+        };
+    },
+};

--- a/test/react-svg-path-precision.js
+++ b/test/react-svg-path-precision.js
@@ -1,0 +1,54 @@
+const path = require("path");
+
+const {rules} = require("../lib/index.js");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["react-svg-path-precision"];
+
+ruleTester.run("react-svg-path-precision", rule, {
+    valid: [
+        {
+            code: '<path d="M1.23,0.45L-0.98,42Z"/>',
+            options: [],
+        },
+        {
+            code: '<div><path d="M1.23,0.45Z"/><path d="M1.23,0.45Z"/></div>',
+            options: [],
+        },
+        {
+            code: '<path d="M1.234,0.456L-0.987,42Z"/>',
+            options: [{precision: 3}],
+        },
+    ],
+    invalid: [
+        {
+            code: '<path d="M1.234,0.456L-0.987,42Z"/>',
+            options: [],
+            errors: [
+                "This path contains numbers with too many decimal places.",
+            ],
+            output: "<path d=M1.23,0.45L-0.98,42Z/>",
+        },
+        {
+            code: '<div><path d="M1.234,0.456Z"/><path d="M1.234,0.456Z"/></div>',
+            options: [],
+            errors: [
+                "This path contains numbers with too many decimal places.",
+                "This path contains numbers with too many decimal places.",
+            ],
+            output: "<div><path d=M1.23,0.45Z/><path d=M1.23,0.45Z/></div>",
+        },
+        {
+            code: '<path d="M1.23,0.45L-0.98,42Z"/>',
+            options: [{precision: 1}],
+            errors: [
+                "This path contains numbers with too many decimal places.",
+            ],
+        },
+    ],
+});

--- a/test/react-svg-path-precision.js
+++ b/test/react-svg-path-precision.js
@@ -49,6 +49,7 @@ ruleTester.run("react-svg-path-precision", rule, {
             errors: [
                 "This path contains numbers with too many decimal places.",
             ],
+            output: "<path d=M1.2,0.4L-0.9,42Z/>",
         },
     ],
 });

--- a/test/react-svg-path-precision.js
+++ b/test/react-svg-path-precision.js
@@ -13,35 +13,35 @@ const rule = rules["react-svg-path-precision"];
 ruleTester.run("react-svg-path-precision", rule, {
     valid: [
         {
-            code: '<path d="M1.23,0.45L-0.98,42Z"/>',
+            code: '<path d="M1.23,.45L-0.98,42Z"/>',
             options: [],
         },
         {
-            code: '<div><path d="M1.23,0.45Z"/><path d="M1.23,0.45Z"/></div>',
+            code: '<div><path d="M1.23,.45Z"/><path d="M1.23,0.45Z"/></div>',
             options: [],
         },
         {
-            code: '<path d="M1.234,0.456L-0.987,42Z"/>',
+            code: '<path d="M1.234,.456L-0.987,42Z"/>',
             options: [{precision: 3}],
         },
     ],
     invalid: [
         {
-            code: '<path d="M1.234,0.456L-0.987,42Z"/>',
+            code: '<path d="M1.234,.456L-0.987,42Z"/>',
             options: [],
             errors: [
                 "This path contains numbers with too many decimal places.",
             ],
-            output: "<path d=M1.23,0.45L-0.98,42Z/>",
+            output: "<path d=M1.23,0.46L-0.99,42Z/>",
         },
         {
-            code: '<div><path d="M1.234,0.456Z"/><path d="M1.234,0.456Z"/></div>',
+            code: '<div><path d="M1.234,.456Z"/><path d="M1.234,.456Z"/></div>',
             options: [],
             errors: [
                 "This path contains numbers with too many decimal places.",
                 "This path contains numbers with too many decimal places.",
             ],
-            output: "<div><path d=M1.23,0.45Z/><path d=M1.23,0.45Z/></div>",
+            output: "<div><path d=M1.23,0.46Z/><path d=M1.23,0.46Z/></div>",
         },
         {
             code: '<path d="M1.23,0.45L-0.98,42Z"/>',
@@ -49,7 +49,7 @@ ruleTester.run("react-svg-path-precision", rule, {
             errors: [
                 "This path contains numbers with too many decimal places.",
             ],
-            output: "<path d=M1.2,0.4L-0.9,42Z/>",
+            output: "<path d=M1.2,0.5L-1.0,42Z/>",
         },
     ],
 });


### PR DESCRIPTION
This rule uses regexes so it should hopefully not be too expensive to run.  If there are really large SVG paths.  A nice to have would be to compute an appropriate precision based on the ratio between SVG size and viewport, but since most of our assets are 1:1 I'm going to leave this as a TODO for now.

The rule also supports autofixing by truncating the number to the desired number of decimal places.  The default is two.