### PR TITLE
Add jest-async-use-real-timers rule.

### DIFF
--- a/docs/jest-async-use-real-timers.md
+++ b/docs/jest-async-use-real-timers.md
@@ -1,0 +1,56 @@
+# Require async tests to call jest.useRealTimers() (jest-async-use-real-timers)
+
+By default jest uses real timers.  Some projects opt to use fake timers
+as a default in order to speed up test execution.  This requires any
+async tests to explicitly call `jest.useRealTimers()`.  This rule can
+be used in this situation to help developers remember to make this call.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+describe("foo", () => {
+    it("requires real timers", async () => {});
+})
+```
+
+```js
+describe("foo", () => {
+    it("requires real timers", async function() {});
+})
+```
+
+The following are not considered warnings:
+
+```js
+describe("foo", () => {
+    it("doesn't require real timers", () => {});
+})
+```
+
+```js
+describe("foo", () => {
+    it("requires real timers", async () => {
+        jest.useRealTimers();
+    });
+})
+```
+
+```js
+describe("foo", () => {
+    it("requires real timers", async function() {
+        jest.useRealTimers();
+    });
+})
+```
+
+```js
+describe("foo", () => {
+    beforeEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("requires real timers", async () => {});
+})
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ module.exports = {
         "flow-exact-state": require("./rules/flow-exact-state.js"),
         "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
+        "jest-async-use-real-timers": require("./rules/jest-async-use-real-timers.js"),
         "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
         "react-svg-path-precision": require("./rules/react-svg-path-precision.js"),

--- a/lib/rules/jest-async-use-real-timers.js
+++ b/lib/rules/jest-async-use-real-timers.js
@@ -1,5 +1,10 @@
 const t = require("@babel/types");
 
+/**
+ * Find and return the `beforeEach` call node inside a describe block if one exists.
+ * 
+ * @param {CallExpression} describeCall the node for a call to `describe`.
+ */
 const findBeforeEach = describeCall => {
     const funcExpr = describeCall.arguments[1];
     if (funcExpr) {
@@ -15,32 +20,19 @@ const findBeforeEach = describeCall => {
     return null;
 }
 
-const usesRealTimers1 = (beforeEachCall) => {
-    if (beforeEachCall == null) {
+/**
+ * Determine if a `beforeEach` or `it` block has called jest.useRealTimers().
+ * 
+ * NOTE: The call cannot be inside a control flow statement.
+ * 
+ * @param {CallExpression} call the node for a call to `beforeEach` or `it`.
+ * @param {number} closureArgIndex the arg index of the closure passed to `call`.
+ */
+const usesRealTimers = (call, closureArgIndex = 0) => {
+    if (call == null) {
         return false;
     }
-    const funcExpr = beforeEachCall.arguments[0];
-
-    if (funcExpr) {
-        for (const stmt of funcExpr.body.body) {
-            if (t.isExpressionStatement(stmt)) {
-                const expr = stmt.expression;
-                if (t.isCallExpression(expr) && t.isMemberExpression(expr.callee)) {
-                    const {object, property} = expr.callee;
-                    if (t.isIdentifier(object, {name: "jest"}) && t.isIdentifier(property, {name: "useRealTimers"}));
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-const usesRealTimers2 = (itCall) => {
-    if (itCall == null) {
-        return false;
-    }
-    const funcExpr = itCall.arguments[1];
+    const funcExpr = call.arguments[closureArgIndex];
 
     if (funcExpr) {
         for (const stmt of funcExpr.body.body) {
@@ -65,7 +57,7 @@ const isAsync = itCall => {
 module.exports = {
     meta: {
         docs: {
-            description: "Ensure that SVG paths don't use too many decimal places",
+            description: "Require a call to jest.useRealTimers() before or in all async tests.",
             category: "react",
             recommended: false,
         },
@@ -83,11 +75,11 @@ module.exports = {
         return {
             CallExpression(node) {
                 if (t.isIdentifier(node.callee, {name: "describe"})) {
-                    stack.push(usesRealTimers1(findBeforeEach(node)));
+                    stack.push(usesRealTimers(findBeforeEach(node), 0));
                 } else if (t.isIdentifier(node.callee, {name: "it"}) && isAsync(node)) {
                     // an `it` should always be inside a `describe`
                     if (stack.length > 0) {
-                        if (configuration === "always" && !stack.some(Boolean) && !usesRealTimers2(node)) {
+                        if (configuration === "always" && !stack.some(Boolean) && !usesRealTimers(node, 1)) {
                             context.report({
                                 node,
                                 message: "Async tests require jest.useRealTimers()."

--- a/lib/rules/jest-async-use-real-timers.js
+++ b/lib/rules/jest-async-use-real-timers.js
@@ -69,31 +69,25 @@ module.exports = {
             category: "react",
             recommended: false,
         },
-        // fixable: "code",
-        // schema: [
-        //     {
-        //         type: "object",
-        //         properties: {
-        //             precision: {
-        //                 type: "number"
-        //             }
-        //         },
-        //         additionalProperties: false
-        //     },
-        // ],
+        schema: [
+            {
+                enum: ["always", "never"],
+            },
+        ],
     },
 
     create(context) {
         const stack = [];
-        let isUsingRealTimers = false;
-        
+        const configuration = context.options[0] || "never";
+
         return {
             CallExpression(node) {
                 if (t.isIdentifier(node.callee, {name: "describe"})) {
                     stack.push(usesRealTimers1(findBeforeEach(node)));
                 } else if (t.isIdentifier(node.callee, {name: "it"}) && isAsync(node)) {
+                    // an `it` should always be inside a `describe`
                     if (stack.length > 0) {
-                        if (!stack.some(Boolean) && !usesRealTimers2(node)) {
+                        if (configuration === "always" && !stack.some(Boolean) && !usesRealTimers2(node)) {
                             context.report({
                                 node,
                                 message: "Async tests require jest.useRealTimers()."
@@ -102,37 +96,11 @@ module.exports = {
                     }
                 }
             },
-
             "CallExpression:exit"(node) {
                 if (t.isIdentifier(node.callee, {name: "describe"})) {
                     stack.pop();
                 }
             }
-
-
-            // JSXAttribute(node) {
-            //     if (t.isJSXAttribute(node) && t.isJSXIdentifier(node.name, {name: "d"})) {
-            //         if (t.isJSXOpeningElement(node.parent) && t.isJSXIdentifier(node.parent.name, {name: "path"})) {
-            //             const d = node.value.value;
-
-            //             if (regex.test(d)) {
-            //                 context.report({
-            //                     fix(fixer) {
-            //                         const replacementText = d.replace(
-            //                             regex, 
-            //                             (match) => parseFloat(match).toFixed(precision),
-            //                         );
-        
-            //                         return fixer.replaceText(node.value, replacementText);
-            //                     },
-            //                     node,
-            //                     message:
-            //                         "This path contains numbers with too many decimal places.",
-            //                 });
-            //             }
-            //         }
-            //     }
-            // },
         };
     },
 };

--- a/lib/rules/jest-async-use-real-timers.js
+++ b/lib/rules/jest-async-use-real-timers.js
@@ -1,0 +1,138 @@
+const t = require("@babel/types");
+
+const findBeforeEach = describeCall => {
+    const funcExpr = describeCall.arguments[1];
+    if (funcExpr) {
+        for (const stmt of funcExpr.body.body) {
+            if (t.isExpressionStatement(stmt)) {
+                const expr = stmt.expression;
+                if (t.isCallExpression(expr) && t.isIdentifier(expr.callee, {name: "beforeEach"})) {
+                    return expr;
+                }
+            }
+        }
+    }
+    return null;
+}
+
+const usesRealTimers1 = (beforeEachCall) => {
+    if (beforeEachCall == null) {
+        return false;
+    }
+    const funcExpr = beforeEachCall.arguments[0];
+
+    if (funcExpr) {
+        for (const stmt of funcExpr.body.body) {
+            if (t.isExpressionStatement(stmt)) {
+                const expr = stmt.expression;
+                if (t.isCallExpression(expr) && t.isMemberExpression(expr.callee)) {
+                    const {object, property} = expr.callee;
+                    if (t.isIdentifier(object, {name: "jest"}) && t.isIdentifier(property, {name: "useRealTimers"}));
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+const usesRealTimers2 = (itCall) => {
+    if (itCall == null) {
+        return false;
+    }
+    const funcExpr = itCall.arguments[1];
+
+    if (funcExpr) {
+        for (const stmt of funcExpr.body.body) {
+            if (t.isExpressionStatement(stmt)) {
+                const expr = stmt.expression;
+                if (t.isCallExpression(expr) && t.isMemberExpression(expr.callee)) {
+                    const {object, property} = expr.callee;
+                    if (t.isIdentifier(object, {name: "jest"}) && t.isIdentifier(property, {name: "useRealTimers"}));
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+const isAsync = itCall => {
+    return t.isArrowFunctionExpression(itCall.arguments[1], {async: true}) ||
+        t.isFunctionExpression(itCall.arguments[1], {async: true});
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Ensure that SVG paths don't use too many decimal places",
+            category: "react",
+            recommended: false,
+        },
+        // fixable: "code",
+        // schema: [
+        //     {
+        //         type: "object",
+        //         properties: {
+        //             precision: {
+        //                 type: "number"
+        //             }
+        //         },
+        //         additionalProperties: false
+        //     },
+        // ],
+    },
+
+    create(context) {
+        const stack = [];
+        let isUsingRealTimers = false;
+        
+        return {
+            CallExpression(node) {
+                if (t.isIdentifier(node.callee, {name: "describe"})) {
+                    stack.push(usesRealTimers1(findBeforeEach(node)));
+                } else if (t.isIdentifier(node.callee, {name: "it"}) && isAsync(node)) {
+                    if (stack.length > 0) {
+                        if (!stack.some(Boolean) && !usesRealTimers2(node)) {
+                            context.report({
+                                node,
+                                message: "Async tests require jest.useRealTimers()."
+                            })
+                        }
+                    }
+                }
+            },
+
+            "CallExpression:exit"(node) {
+                if (t.isIdentifier(node.callee, {name: "describe"})) {
+                    stack.pop();
+                }
+            }
+
+
+            // JSXAttribute(node) {
+            //     if (t.isJSXAttribute(node) && t.isJSXIdentifier(node.name, {name: "d"})) {
+            //         if (t.isJSXOpeningElement(node.parent) && t.isJSXIdentifier(node.parent.name, {name: "path"})) {
+            //             const d = node.value.value;
+
+            //             if (regex.test(d)) {
+            //                 context.report({
+            //                     fix(fixer) {
+            //                         const replacementText = d.replace(
+            //                             regex, 
+            //                             (match) => parseFloat(match).toFixed(precision),
+            //                         );
+        
+            //                         return fixer.replaceText(node.value, replacementText);
+            //                     },
+            //                     node,
+            //                     message:
+            //                         "This path contains numbers with too many decimal places.",
+            //                 });
+            //             }
+            //         }
+            //     }
+            // },
+        };
+    },
+};

--- a/test/jest-async-use-real-timers.js
+++ b/test/jest-async-use-real-timers.js
@@ -1,0 +1,140 @@
+const path = require("path");
+
+const {rules} = require("../lib/index.js");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["jest-async-use-real-timers"];
+
+ruleTester.run("jest-real-timers", rule, {
+    valid: [
+        {
+            code: `
+describe("foo", () => {
+    it("doesn't require real timers", () => {});
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async () => {
+        jest.useRealTimers();
+    });
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async function() {
+        jest.useRealTimers();
+    });
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    beforeEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("requires real timers", async () => {});
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    beforeEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe("bar", () => {
+        it("requires real timers", async () => {});
+    });
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    describe("bar", () => {
+        beforeEach(() => {
+            jest.useRealTimers();
+        });
+
+        it("requires real timers", async () => {});
+    });
+})`,
+            options: [],
+        },
+    ],
+    invalid: [
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async () => {});
+})`,
+            options: [],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async function() {});
+})`,
+            options: [],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
+        },
+        {
+            code: `
+describe("foo", () => {
+    beforeEach(() => {});
+
+    it("requires real timers", async () => {});
+})`,
+            options: [],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
+        },
+        {
+            code: `
+describe("foo", () => {
+    beforeEach(() => {});
+
+    describe("bar", () => {
+        it("requires real timers", async () => {});
+    });
+})`,
+            options: [],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
+        },
+        {
+            code: `
+describe("foo", () => {
+    describe("bar", () => {
+        beforeEach(() => {});
+
+        it("requires real timers", async () => {});
+    });
+})`,
+            options: [],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
+        },
+    ],
+});

--- a/test/jest-async-use-real-timers_test.js
+++ b/test/jest-async-use-real-timers_test.js
@@ -17,7 +17,7 @@ ruleTester.run("jest-real-timers", rule, {
 describe("foo", () => {
     it("doesn't require real timers", () => {});
 })`,
-            options: [],
+            options: ["always"],
         },
         {
             code: `
@@ -26,7 +26,7 @@ describe("foo", () => {
         jest.useRealTimers();
     });
 })`,
-            options: [],
+            options: ["always"],
         },
         {
             code: `
@@ -35,7 +35,7 @@ describe("foo", () => {
         jest.useRealTimers();
     });
 })`,
-            options: [],
+            options: ["always"],
         },
         {
             code: `
@@ -46,7 +46,7 @@ describe("foo", () => {
 
     it("requires real timers", async () => {});
 })`,
-            options: [],
+            options: ["always"],
         },
         {
             code: `
@@ -59,7 +59,7 @@ describe("foo", () => {
         it("requires real timers", async () => {});
     });
 })`,
-            options: [],
+            options: ["always"],
         },
         {
             code: `
@@ -72,7 +72,17 @@ describe("foo", () => {
         it("requires real timers", async () => {});
     });
 })`,
-            options: [],
+            options: ["always"],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async () => {});
+})`,
+            options: ["never"],
+            errors: [
+                "Async tests require jest.useRealTimers().",
+            ],
         },
     ],
     invalid: [
@@ -81,7 +91,7 @@ describe("foo", () => {
 describe("foo", () => {
     it("requires real timers", async () => {});
 })`,
-            options: [],
+            options: ["always"],
             errors: [
                 "Async tests require jest.useRealTimers().",
             ],
@@ -91,7 +101,7 @@ describe("foo", () => {
 describe("foo", () => {
     it("requires real timers", async function() {});
 })`,
-            options: [],
+            options: ["always"],
             errors: [
                 "Async tests require jest.useRealTimers().",
             ],
@@ -103,7 +113,7 @@ describe("foo", () => {
 
     it("requires real timers", async () => {});
 })`,
-            options: [],
+            options: ["always"],
             errors: [
                 "Async tests require jest.useRealTimers().",
             ],
@@ -117,7 +127,7 @@ describe("foo", () => {
         it("requires real timers", async () => {});
     });
 })`,
-            options: [],
+            options: ["always"],
             errors: [
                 "Async tests require jest.useRealTimers().",
             ],
@@ -131,7 +141,7 @@ describe("foo", () => {
         it("requires real timers", async () => {});
     });
 })`,
-            options: [],
+            options: ["always"],
             errors: [
                 "Async tests require jest.useRealTimers().",
             ],


### PR DESCRIPTION
By default jest uses real timers.  Some projects opt to use fake timers as a default in order to speed up test execution.  This requires any async tests to explicitly call `jest.useRealTimers()`.  This rule can be used in this situation to help developers remember to make this call.