### PR TITLE
specify 'files' in package.json so we don't include everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "/lib"
+  ],
   "main": "lib/index.js",
   "repository": "https://github.com/Khan/eslint-plugin-khan",
   "author": "Kevin Barabash <kevinb@khanacademy.org>",


### PR DESCRIPTION
We were package everything including tests and node_modules which ended up adding a lot of files in khan-linter.