### PR TITLE
Handle some edge cases in jest-async-use-real-timers

### DIFF
--- a/lib/rules/jest-async-use-real-timers.js
+++ b/lib/rules/jest-async-use-real-timers.js
@@ -7,7 +7,12 @@ const t = require("@babel/types");
  */
 const findBeforeEach = describeCall => {
     const funcExpr = describeCall.arguments[1];
-    if (funcExpr) {
+    if (
+        funcExpr &&
+        (t.isArrowFunctionExpression(funcExpr) ||
+            t.isFunctionExpression(funcExpr)) &&
+        t.isBlockStatement(funcExpr.body)
+    ) {
         for (const stmt of funcExpr.body.body) {
             if (t.isExpressionStatement(stmt)) {
                 const expr = stmt.expression;
@@ -37,7 +42,12 @@ const usesRealTimers = (call, closureArgIndex = 0) => {
     }
     const funcExpr = call.arguments[closureArgIndex];
 
-    if (funcExpr) {
+    if (
+        funcExpr &&
+        (t.isArrowFunctionExpression(funcExpr) ||
+            t.isFunctionExpression(funcExpr)) &&
+        t.isBlockStatement(funcExpr.body)
+    ) {
         for (const stmt of funcExpr.body.body) {
             if (t.isExpressionStatement(stmt)) {
                 const expr = stmt.expression;

--- a/test/jest-async-use-real-timers_test.js
+++ b/test/jest-async-use-real-timers_test.js
@@ -74,6 +74,32 @@ describe("foo", () => {
 })`,
             options: [],
         },
+        {
+            code: `describe("foo", fn)`,
+            options: [],
+        },
+        {
+            code: `describe("foo", () => fn())`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", asyncFn);
+})`,
+            options: [],
+        },
+        {
+            code: `
+describe("foo", () => {
+    beforeEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("requires real timers", async () => asyncFn());
+})`,
+            options: [],
+        },
     ],
     invalid: [
         {
@@ -122,6 +148,14 @@ describe("foo", () => {
 
         it("requires real timers", async () => {});
     });
+})`,
+            options: [],
+            errors: ["Async tests require jest.useRealTimers()."],
+        },
+        {
+            code: `
+describe("foo", () => {
+    it("requires real timers", async () => asyncFn());
 })`,
             options: [],
             errors: ["Async tests require jest.useRealTimers()."],


### PR DESCRIPTION
In particular there are some places in webapp where we use one-liner arrow functions in some of the test harnesses.  This PR handles that as well as passing a named function instead of an arrow or function expression.
