### PR TITLE
Add jest-enzyme-matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ eslint plugin with our set of custom rules for various things
 - [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
 - [khan/jest-async-use-real-timers](docs/jest-async-use-real-timers.md)
+- [khan/jest-enzyme-matchers](docs/jest-enzyme-matchers.md)
 - [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)
 - [khan/react-svg-path-precision](docs/react-svg-path-precision.md)

--- a/docs/jest-enzyme-matchers.md
+++ b/docs/jest-enzyme-matchers.md
@@ -1,0 +1,76 @@
+# Require the use of enzyme matchers when possible (jest-enzyme-matchers)
+
+[jest-enzyme](https://github.com/FormidableLabs/enzyme-matchers/tree/master/packages/jest-enzyme#readme)
+provides a number of matchers that useful when writing enzyme tests.  Using these
+matchers providers better error messages when there are test failures.  This rule
+supporters auto-fixing.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+expect(wrapper.first().prop("foo")).toEqual("bar");
+```
+
+```js
+expect(wrapper.first().state("foo")).toEqual("bar");
+```
+
+```js
+expect(wrapper.find(".foo")).toHaveLength(2);
+```
+
+```js
+expect(wrapper.find(".foo").text()).toEqual("bar");
+```
+
+```js
+expect(wrapper.find(".foo").html()).toEqual("<p>bar</p>");
+```
+
+```js
+expect(wrapper.find(".foo").exists()).toBeTrue();
+```
+
+```js
+expect(wrapper.exists(".foo")).toBeTrue();
+```
+
+```js
+expect(wrapper.find(".foo").exists()).toBeFalse();
+```
+
+```js
+expect(wrapper.exists(".foo")).toBeFalse();
+```
+
+The following are not considered warnings:
+
+```js
+expect(wrapper).toHaveProp("foo", "bar");
+```
+
+```js
+expect(wrapper).toHaveState("foo", "bar");
+```
+
+```js
+expect(wrapper).toContainMatchingElements(2, ".foo");
+```
+
+```js
+expect(wrapper.find(".foo")).toHaveText("bar");
+```
+
+```js
+expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");
+```
+
+```js
+expect(wrapper.find(".foo")).toExist();
+```
+
+```js
+expect(wrapper).toContainMatchingElement(".foo");
+```

--- a/docs/jest-enzyme-matchers.md
+++ b/docs/jest-enzyme-matchers.md
@@ -7,70 +7,58 @@ supporters auto-fixing.
 
 ## Rule Details
 
-The following are considered warnings:
-
 ```js
+// Invalid
 expect(wrapper.first().prop("foo")).toEqual("bar");
-```
 
-```js
-expect(wrapper.first().state("foo")).toEqual("bar");
-```
-
-```js
-expect(wrapper.find(".foo")).toHaveLength(2);
-```
-
-```js
-expect(wrapper.find(".foo").text()).toEqual("bar");
-```
-
-```js
-expect(wrapper.find(".foo").html()).toEqual("<p>bar</p>");
-```
-
-```js
-expect(wrapper.find(".foo").exists()).toBeTrue();
-```
-
-```js
-expect(wrapper.exists(".foo")).toBeTrue();
-```
-
-```js
-expect(wrapper.find(".foo").exists()).toBeFalse();
-```
-
-```js
-expect(wrapper.exists(".foo")).toBeFalse();
-```
-
-The following are not considered warnings:
-
-```js
+// Valid
 expect(wrapper).toHaveProp("foo", "bar");
 ```
 
 ```js
+// Invalid
+expect(wrapper.first().state("foo")).toEqual("bar");
+
+// Valid
 expect(wrapper).toHaveState("foo", "bar");
 ```
 
 ```js
+// Invalid
+expect(wrapper.find(".foo")).toHaveLength(2);
+
+// Valid
 expect(wrapper).toContainMatchingElements(2, ".foo");
 ```
 
 ```js
+// Invalid
+expect(wrapper.find(".foo").text()).toEqual("bar");
+
+// Valid
 expect(wrapper.find(".foo")).toHaveText("bar");
 ```
 
 ```js
+// Invalid
+expect(wrapper.find(".foo").html()).toEqual("<p>bar</p>");
+
+// Valid
 expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");
 ```
 
 ```js
+// Invalid
+expect(wrapper.find(".foo").exists()).toBeTrue();
+
+// Valid
 expect(wrapper.find(".foo")).toExist();
 ```
 
 ```js
-expect(wrapper).toContainMatchingElement(".foo");
+// Invalid
+expect(wrapper.find(".foo").exists()).toBeFalse();
+
+// Valid
+expect(wrapper.find(".foo")).not.toExist();
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ module.exports = {
         "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
         "jest-async-use-real-timers": require("./rules/jest-async-use-real-timers.js"),
+        "jest-enzyme-matchers": require("./rules/jest-enzyme-matchers.js"),
         "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
         "react-svg-path-precision": require("./rules/react-svg-path-precision.js"),

--- a/lib/rules/jest-async-use-real-timers.js
+++ b/lib/rules/jest-async-use-real-timers.js
@@ -80,7 +80,7 @@ module.exports = {
         docs: {
             description:
                 "Require a call to jest.useRealTimers() before or in all async tests.",
-            category: "react",
+            category: "jest",
             recommended: false,
         },
     },

--- a/lib/rules/jest-enzyme-matchers.js
+++ b/lib/rules/jest-enzyme-matchers.js
@@ -1,0 +1,232 @@
+const t = require("@babel/types");
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "Requires the use more of enzyme matchers where appropriate.",
+            category: "jes",
+            recommended: false,
+        },
+        fixable: true,
+    },
+
+    create(context) {
+        const stack = [];
+
+        return {
+            CallExpression(node) {
+                if (
+                    t.isIdentifier(node.callee, {name: "expect"}) &&
+                    t.isCallExpression(node.arguments[0]) &&
+                    t.isMemberExpression(node.arguments[0].callee) &&
+                    t.isMemberExpression(node.parent) &&
+                    t.isIdentifier(node.parent.property) &&
+                    t.isCallExpression(node.parent.parent)
+                ) {
+                    const {property} = node.arguments[0].callee;
+                    const matcher = node.parent.property.name;
+
+                    if (matcher === "toEqual") {
+                        if (t.isIdentifier(property, {name: "prop"})) {
+                            const sourceCode = context.getSource();
+                            const propName = node.arguments[0].arguments[0];
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveProp(${propName.raw}, ${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveProp(${propName.raw}, ${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "state"})) {
+                            const sourceCode = context.getSource();
+                            const stateKey = node.arguments[0].arguments[0];
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveState(${stateKey.raw}, ${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveState(${stateKey.raw}, ${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "text"})) {
+                            const sourceCode = context.getSource();
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveText(${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveText(${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "html"})) {
+                            const sourceCode = context.getSource();
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveHTML(${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveHTML(${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        }
+                    } else if (
+                        matcher === "toBeTrue" ||
+                        matcher === "toBeTruthy"
+                    ) {
+                        if (t.isIdentifier(property, {name: "exists"})) {
+                            if (node.arguments[0].arguments.length === 0) {
+                                const sourceCode = context.getSource();
+                                context.report({
+                                    node,
+                                    message: `Use .toExist() instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).toExist()`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            } else {
+                                const sourceCode = context.getSource();
+                                const selector = sourceCode.slice(
+                                    ...node.arguments[0].arguments[0].range,
+                                );
+                                context.report({
+                                    node,
+                                    message: `Use .toContainMatchingElement(${selector}) instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).toContainMatchingElement(${selector})`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            }
+                        }
+                    } else if (
+                        matcher === "toBeFalse" ||
+                        matcher === "toBeFalsy"
+                    ) {
+                        if (t.isIdentifier(property, {name: "exists"})) {
+                            if (node.arguments[0].arguments.length === 0) {
+                                const sourceCode = context.getSource();
+                                context.report({
+                                    node,
+                                    message: `Use .not.toExist() instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).not.toExist()`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            } else {
+                                const sourceCode = context.getSource();
+                                const selector = sourceCode.slice(
+                                    ...node.arguments[0].arguments[0].range,
+                                );
+                                context.report({
+                                    node,
+                                    message: `Use .not.toContainMatchingElement(${selector}) instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).not.toContainMatchingElement(${selector})`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            }
+                        }
+                    } else if (matcher === "toHaveLength") {
+                        if (t.isIdentifier(property, {name: "find"})) {
+                            const sourceCode = context.getSource();
+                            const selector = sourceCode.slice(
+                                ...node.arguments[0].arguments[0].range,
+                            );
+                            const count = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toContainMatchingElements(${count}, ${selector}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toContainMatchingElements(${count}, ${selector})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        }
+                    }
+                }
+            },
+        };
+    },
+};

--- a/test/jest-enzyme-matchers_test.js
+++ b/test/jest-enzyme-matchers_test.js
@@ -1,0 +1,150 @@
+const path = require("path");
+
+const {rules} = require("../lib/index.js");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["jest-enzyme-matchers"];
+
+ruleTester.run("jest-real-timers", rule, {
+    valid: [
+        {
+            code: 'expect(wrapper).toHaveProp("foo", "bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toHaveState("foo", "bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toContainMatchingElements(1, ".foo");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toHaveText("bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toExist();',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toContainMatchingElement(".foo");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).not.toExist();',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+            options: [],
+        },
+    ],
+    invalid: [
+        {
+            code: `expect(wrapper.prop("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveProp("foo", "bar") instead.'],
+            output: 'expect(wrapper).toHaveProp("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.first().prop("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveProp("foo", "bar") instead.'],
+            output: 'expect(wrapper.first()).toHaveProp("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.state("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveState("foo", "bar") instead.'],
+            output: 'expect(wrapper).toHaveState("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.first().state("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveState("foo", "bar") instead.'],
+            output: 'expect(wrapper.first()).toHaveState("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.find(".foo")).toHaveLength(1);`,
+            options: [],
+            errors: ['Use .toContainMatchingElements(1, ".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElements(1, ".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo")).toHaveLength(2);`,
+            options: [],
+            errors: ['Use .toContainMatchingElements(2, ".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElements(2, ".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").text()).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveText("bar") instead.'],
+            output: 'expect(wrapper.find(".foo")).toHaveText("bar");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").html()).toEqual("<p>bar</p>");`,
+            options: [],
+            errors: ['Use .toHaveHTML("<p>bar</p>") instead.'],
+            output: 'expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeTrue();`,
+            options: [],
+            errors: ["Use .toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).toExist();',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeTruthy();`,
+            options: [],
+            errors: ["Use .toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).toExist();',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeTrue();`,
+            options: [],
+            errors: ['Use .toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeTruthy();`,
+            options: [],
+            errors: ['Use .toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeFalse();`,
+            options: [],
+            errors: ["Use .not.toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).not.toExist();',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeFalsy();`,
+            options: [],
+            errors: ["Use .not.toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).not.toExist();',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeFalse();`,
+            options: [],
+            errors: ['Use .not.toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeFalsy();`,
+            options: [],
+            errors: ['Use .not.toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new rule that checks for the use of some of the matchers in [jest-matchers](https://github.com/FormidableLabs/enzyme-matchers/tree/master/packages/jest-enzyme#readme):`.toHaveProp`, `.toHaveState`, `.toContainMatchingElements`, `.toHaveText`, `.toHaveHTML`, `.toExist`, `.toContainMatchingElement`.  This rule supports auto-fixing, e.g.

```js
expect(wrapper.prop("foo")).toEqual("bar"); 
    -> expect(wrapper).toHaveProp("foo", "bar");
```

The main limitation of this rule is that it doesn't support the following yet:
```js
expect(wrapper.prop("foo")).not.toEqual("bar");
```

I'll add try to add support for this in a future PR when I have more time.