### PR TITLE
Add `sync-tag` rule

### DIFF
--- a/docs/sync-tag.md
+++ b/docs/sync-tag.md
@@ -1,0 +1,11 @@
+# Ensure that sync tags are valid
+
+Sync tags provide a way keep code in separate files in sync.  This lint rule
+uses [checksync](https://github.com/somewhatabstract/checksync) to validate
+sync tags and provide fixes when possible. 
+
+Notes:
+- All paths in `ignoreFiles` are considered to be relative to `rootDir`.
+- `rootDir` is required and should usually be set to the root directory of the
+  repo.  This requires the the configuration of `khan/sync-tags` to be done in
+  a `.js` file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,5 +10,6 @@ module.exports = {
         "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
         "react-svg-path-precision": require("./rules/react-svg-path-precision.js"),
+        "sync-tag": require("./rules/sync-tag.js"),
     },
 };

--- a/lib/rules/sync-tag.js
+++ b/lib/rules/sync-tag.js
@@ -1,0 +1,114 @@
+const path = require("path");
+const ancesdir = require("ancesdir");
+
+const util = require("../util.js");
+
+const pkgRoot = ancesdir(__dirname, ".pkg_root");
+
+const UPDATE_REMINDER =
+    "If necessary, check the sync-tag target and make relevant changes before updating the checksum.";
+
+const processItem = (item, node, context, comments) => {
+    if (item.sourceLine && item.message) {
+        const line = item.sourceLine;
+        const comment = comments.find(
+            comment => comment.loc.start.line === line,
+        );
+
+        if (item.fix) {
+            context.report({
+                node: comment,
+                message: `${item.message} ${UPDATE_REMINDER}`,
+                fix(fixer) {
+                    return fixer.replaceText(comment, item.fix.trim());
+                },
+            });
+        } else {
+            context.report({
+                node: comment,
+                message: item.message,
+            });
+        }
+    } else if (item.message) {
+        context.report({
+            node: node,
+            message: `${item.message} ${UPDATE_REMINDER}`,
+        });
+    } else {
+        // eslint-disable-next-line no-console
+        console.error(`Unknown item type ${item.type}`);
+    }
+};
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Ensure sync tags are valid",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    ignoreFiles: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
+                    },
+                    rootDir: {
+                        type: "string",
+                    },
+                },
+            },
+        ],
+        fixable: "code",
+    },
+
+    create(context) {
+        const ignoreFiles = (context.options[0].ignoreFiles || []).join(",");
+        const rootDir = context.options[0].rootDir;
+        if (!rootDir) {
+            throw new Error("rootDir must be set");
+        }
+
+        return {
+            Program(node) {
+                const syncStartComments = node.comments.filter(comment =>
+                    comment.value.trim().startsWith("sync-start:"),
+                );
+
+                const shouldChecksync = syncStartComments.length > 0;
+
+                if (shouldChecksync) {
+                    const filename = path.relative(
+                        rootDir,
+                        context.getFilename(),
+                    );
+                    const checksyncPath = path.join(
+                        pkgRoot,
+                        "node_modules",
+                        ".bin",
+                        "checksync",
+                    );
+
+                    const command = `${checksyncPath} ${filename} -c "//,#,{/*,{{/*" -m .ka_root --ignore-files ${ignoreFiles} --json`;
+                    const stdout = util.execSync(command, {
+                        cwd: rootDir,
+                        encoding: "utf-8",
+                    });
+
+                    try {
+                        const data = JSON.parse(stdout);
+                        for (const item of data.items) {
+                            processItem(item, node, context, syncStartComments);
+                        }
+                    } catch (e) {
+                        // eslint-disable-next-line no-console
+                        console.error(e);
+                        return;
+                    }
+                }
+            },
+        };
+    },
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,6 @@
+const {execSync} = require("child_process");
+
+// This is done so that we can override execSync in the tests
+module.exports = {
+    execSync,
+};

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "scripts": {
     "test": "mocha test/**/*.js",
     "prettier": "prettier --write '{lib,test}/**/*.js'",
-    "prepublish": "npm run test"
+    "prepublishOnly": "npm run test"
   },
   "dependencies": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.7.4",
+    "ancesdir": "^2.0.2",
+    "checksync": "^2.3.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khanacademy/eslint-plugin",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/test/sync-tag_test.js
+++ b/test/sync-tag_test.js
@@ -1,0 +1,79 @@
+const {rules} = require("../lib/index.js");
+const util = require("../lib/util.js");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["sync-tag"];
+
+util.execSync = command => {
+    console.log("execSync mock --------");
+    if (command.includes("filea")) {
+        const json = JSON.stringify({
+            version: "2.2.3",
+            launchString: "",
+            items: [],
+        });
+        return json;
+    }
+    if (command.includes("filex")) {
+        return JSON.stringify({
+            version: "2.2.3",
+            launchString: "",
+            items: [
+                {
+                    type: "violation",
+                    sourceFile: "filex",
+                    sourceLine: 2,
+                    targetFile: "filey",
+                    targetLine: 23,
+                    message: `filex:15 Updating checksum for sync-tag 'foo-bar' referencing 'filey:23' from No checksum to 1424803960.`,
+                    fix: "// sync-start:foo-bar 1424803960 filey",
+                },
+            ],
+        });
+    }
+    return "";
+};
+
+ruleTester.run("require-static-url", rule, {
+    valid: [
+        {
+            code:
+                "// sync-start:foo-bar 1424803960 fileb\nconst FooBar = 'foobar';\n// sync-end:foobar",
+            filename: "filea",
+            options: [
+                {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                // sync-start:foo-bar filey
+                const FooBar = 'foobar';
+                // sync-end:foobar`,
+            filename: "filex",
+            errors: [
+                "filex:15 Updating checksum for sync-tag 'foo-bar' referencing 'filey:23' from No checksum to 1424803960. " +
+                    "If necessary, check the sync-tag target and make relevant changes before updating the checksum.",
+            ],
+            output: `
+                // sync-start:foo-bar 1424803960 filey
+                const FooBar = 'foobar';
+                // sync-end:foobar`,
+            options: [
+                {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+    ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,11 @@ ajv@^6.10.2, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ancesdir@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ancesdir/-/ancesdir-2.0.2.tgz#5006a43e3e212c9ba0d7cdd91cfca1f88967e9fe"
+  integrity sha512-xdE0k/jTXIXNKcIH1rKwXKriDijJUY2Y8QHsZ7GFXJyI3upmz2EWMQ2WKdBS8qO7u52+Sa9IT6/NpKl4nkYeGg==
+
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -262,6 +267,11 @@ chalk@^3.0.0:
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+
+checksync@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/checksync/-/checksync-2.3.0.tgz#d0801971aaa84a0adbc33734d1dab18f87ed54bd"
+  integrity sha512-QhR8MfvqAjo574gILPhGa1+j2NCyhhBC9biY1jigaPOnrtCO23QO+U+4cGfsw0IINXJd3yk6kcNtRKs5JYCdpg==
 
 ci-info@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
This rule was originally implemented in webapp in services/static/dev/eslint-plugin-static-service, but I ran into issues ensuring that its deps were being installed so I decided to move this rule over to this repo.  Since this will be published and installed into services/static/ like a normal npm package it should just work.  This will also make it easier for other js-based services within webapp to adopt this rule.

## Test Plan
- `yarn test`
- use `yarn link` to enable this rule in webapp/services/static
- update webapp/services/static/.eslintrc.js to use the new rule (see https://github.com/Khan/webapp/pull/684)
- test some files to see that the rule works webapp