### PR TITLE
Drop the use of ancesdir so that we don't have to include .pkg_root in the package

### DIFF
--- a/lib/rules/sync-tag.js
+++ b/lib/rules/sync-tag.js
@@ -1,9 +1,8 @@
 const path = require("path");
-const ancesdir = require("ancesdir");
 
 const util = require("../util.js");
 
-const pkgRoot = ancesdir(__dirname, ".pkg_root");
+const PKG_ROOT = path.join(__dirname, "..", "..");
 
 const UPDATE_REMINDER =
     "If necessary, check the sync-tag target and make relevant changes before updating the checksum.";
@@ -85,7 +84,7 @@ module.exports = {
                         context.getFilename(),
                     );
                     const checksyncPath = path.join(
-                        pkgRoot,
+                        PKG_ROOT,
                         "node_modules",
                         ".bin",
                         "checksync",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@babel/types": "^7.7.4",
-    "ancesdir": "^2.0.2",
     "checksync": "^2.3.0"
   },
   "husky": {


### PR DESCRIPTION
`ancesdir` was failing to find `.pkg_root` when installing `@khanacademy/eslint-plugin` from npm since the files wasn't included in the package.  The package.json only includes files from `/lib`.

I tested this using `yarn link` as described in #22.