### PR TITLE
Make it so that subfiles of listed modules are also covered by the rule

### DIFF
--- a/docs/imports-requiring-flow.md
+++ b/docs/imports-requiring-flow.md
@@ -5,9 +5,12 @@ rely on flow to catch issues when refactoring those modules.  This rule
 requires that any files importing one of the specified modules be using
 flow as indicated by a `// @flow` comment in the file.
 
+This rule also works with directories, so that any modules under that directory
+or its subdirectories are required to be using flow types.
+
 Notes:
-- All paths in `modules` that aren't npm packages are considered to be
-  relative to `rootDir`.
+- All paths in `modules` that aren't npm packages (i.e. are directories or files
+  within your codebase) are considered to be relative to `rootDir`.
 - `rootDir` is required and should usually be set to `__dirname`.  This
   requires the the configuration of `khan/imports-requiring-flow` to be
   done in a `.js` file.
@@ -16,7 +19,7 @@ Notes:
 
 Give the following rule config:
 
-```
+```js
 "khan/imports-requiring-flow": [
     "error", {
         rootDir: __dirname,
@@ -32,11 +35,19 @@ import foo from "foo";
 ```
 
 ```js
+import foo from "foo/bar";
+```
+
+```js
 import bar from "./bar";
 ```
 
 ```js
 const foo = require("foo");
+```
+
+```js
+const foo = require("foo/bar");
 ```
 
 ```js
@@ -52,12 +63,22 @@ import foo from "foo";
 
 ```js
 // @flow
+import foo from "foo/bar";
+```
+
+```js
+// @flow
 import bar from "./bar";
 ```
 
 ```js
 // @flow
 const foo = require("foo");
+```
+
+```js
+// @flow
+const foo = require("foo/bar");
 ```
 
 ```js

--- a/lib/rules/imports-requiring-flow.js
+++ b/lib/rules/imports-requiring-flow.js
@@ -3,26 +3,39 @@ const path = require("path");
 const checkImport = (context, rootDir, importPath, node) => {
     const modules = context.options[0].modules || [];
 
+    const maybeReport = (importPath, testRulePath, testImportPath) => {
+        // TODO(somewhatabstract): This is not cross-platform. We need to do
+        // more work to make this rule work on Windows properly, regardless of
+        // the configuration format.
+        const subRulePath = testRulePath.endsWith(path.sep)
+            ? testRulePath
+            : `${testRulePath}${path.sep}`;
+
+        // If the path is the same, then it's a match for the error.
+        // If the path starts with the module listed, then it's also a match.
+        if (
+            testImportPath === testRulePath ||
+            testImportPath.startsWith(subRulePath)
+        ) {
+            context.report({
+                node,
+                message: `Importing "${importPath}" requires using flow.`,
+            });
+            return true;
+        }
+        return false;
+    };
+
     for (const mod of modules) {
         if (importPath.startsWith(".")) {
             const filename = context.getFilename();
             const absImportPath = path.join(path.dirname(filename), importPath);
             const absModPath = path.join(rootDir, mod);
-            if (absModPath === absImportPath) {
-                const message = `Importing "${importPath}" requires using flow.`;
-                context.report({
-                    node: node,
-                    message: message,
-                });
+            if (maybeReport(importPath, absModPath, absImportPath)) {
                 break;
             }
         } else {
-            if (mod === importPath) {
-                const message = `Importing "${importPath}" requires using flow.`;
-                context.report({
-                    node: node,
-                    message: message,
-                });
+            if (maybeReport(importPath, mod, importPath)) {
                 break;
             }
         }
@@ -64,11 +77,8 @@ module.exports = {
         if (!rootDir) {
             throw new Error("rootDir must be set");
         }
-        const source = context.getSource();
-        const filename = context.getFilename();
 
         let usingFlow = false;
-
         return {
             Program(node) {
                 usingFlow = node.comments.some(

--- a/test/imports-requiring-flow_test.js
+++ b/test/imports-requiring-flow_test.js
@@ -97,6 +97,16 @@ ruleTester.run("imports-requiring-flow", rule, {
             ],
         },
         {
+            code: importBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/"],
+                    rootDir,
+                },
+            ],
+        },
+        {
             code: requireFooPkgFlow,
             filename: path.join(rootDir, "src/package-1/foobar.js"),
             options: [
@@ -117,6 +127,16 @@ ruleTester.run("imports-requiring-flow", rule, {
             ],
         },
         {
+            code: dynamicImportBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2"],
+                    rootDir,
+                },
+            ],
+        },
+        {
             code: dynamicImportFooPkgFlow,
             filename: path.join(rootDir, "src/package-1/foobar.js"),
             options: [
@@ -132,6 +152,16 @@ ruleTester.run("imports-requiring-flow", rule, {
             options: [
                 {
                     modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: requireBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2"],
                     rootDir,
                 },
             ],
@@ -221,6 +251,17 @@ ruleTester.run("imports-requiring-flow", rule, {
             errors: ['Importing "../package-2/bar.js" requires using flow.'],
         },
         {
+            code: importBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
+        },
+        {
             code: requireFooPkgNoflow,
             filename: path.join(rootDir, "src/package-1/foobar.js"),
             options: [
@@ -230,6 +271,17 @@ ruleTester.run("imports-requiring-flow", rule, {
                 },
             ],
             errors: ['Importing "foo" requires using flow.'],
+        },
+        {
+            code: requireBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
         },
         {
             code: requireBarModNoflow,
@@ -259,6 +311,17 @@ ruleTester.run("imports-requiring-flow", rule, {
             options: [
                 {
                     modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
+        },
+        {
+            code: dynamicImportBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2"],
                     rootDir,
                 },
             ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,11 +128,6 @@ ajv@^6.10.2, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ancesdir@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ancesdir/-/ancesdir-2.0.2.tgz#5006a43e3e212c9ba0d7cdd91cfca1f88967e9fe"
-  integrity sha512-xdE0k/jTXIXNKcIH1rKwXKriDijJUY2Y8QHsZ7GFXJyI3upmz2EWMQ2WKdBS8qO7u52+Sa9IT6/NpKl4nkYeGg==
-
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"


### PR DESCRIPTION
## Summary:
This makes it easier to use the `imports-requiring-flow` rule by ensuring that
sub-paths of a module are also considered. This will allow us to check for
files within a module or folder from just the module name rather than listing
each file.

Issue: None

## Test plan:
`yarn test`