### PR TITLE
FEI-4164: Lint rule to ensure we're await-ing async matchers

### DIFF
--- a/docs/imports-requiring-flow.md
+++ b/docs/imports-requiring-flow.md
@@ -12,7 +12,7 @@ Notes:
 - All paths in `modules` that aren't npm packages (i.e. are directories or files
   within your codebase) are considered to be relative to `rootDir`.
 - `rootDir` is required and should usually be set to `__dirname`.  This
-  requires the the configuration of `khan/imports-requiring-flow` to be
+  requires the the configuration of `@khanacademy/imports-requiring-flow` to be
   done in a `.js` file.
 
 ## Rule Details
@@ -20,7 +20,7 @@ Notes:
 Give the following rule config:
 
 ```js
-"khan/imports-requiring-flow": [
+"@khanacademy/imports-requiring-flow": [
     "error", {
         rootDir: __dirname,
         modules: ["foo", "src/bar.js"],

--- a/docs/jest-await-async-matchers.md
+++ b/docs/jest-await-async-matchers.md
@@ -1,0 +1,120 @@
+# Require async matchers to be awaited (jest-await-async-matchers)
+
+Matchers that contain asynchronous computations must be awaited to operate correctly.
+If they aren't, a test could pass even if it should fail.  This is because the
+matcher hasn't finished running.  This rule can help ensure that we're `await`-ing
+those matchers that need it.  By default the following matchers must be `await`-ed
+with this rule: `.resolves.`, `.rejects.`, `.toResolve()`, and `.toReject()`.  Custom
+matchers can be added to this list using the `matchers` option.
+
+## Rule Details
+
+Give the following rule config:
+
+```js
+"@khanacademy/jest": [
+    "error", {
+        matchers: ["toHaveMarkedConversion"],
+    },
+]
+```
+
+The following are considered warnings:
+
+```js
+async () => {
+    expect(callback).toHaveMarkedConversion();
+}
+```
+
+```js
+async () => {
+    expect(callback).not.toHaveMarkedConversion();
+}
+```
+
+```js
+async () => {
+    expect(promise).resolves.toBe(true);
+}
+```
+
+```js
+async () => {
+    expect(promise).resolves.not.toBe(true);
+}
+```
+
+```js
+async () => {
+    expect(promise).rejects.toThrow(new Error("bar"));
+}
+```
+
+```js
+async () => {
+    expect(promise).rejects.not.toThrow(new Error("bar"));
+}
+```
+
+```js
+async () => {
+    expect(promise).toResolve();
+}
+```
+
+```js
+async () => {
+    expect(promise).toReject();
+}
+```
+
+The following are not considered warnings:
+
+```js
+async () => {
+    await expect(callback).toHaveMarkedConversion();
+}
+```
+
+```js
+async () => {
+    await expect(callback).not.toHaveMarkedConversion();
+}
+```
+
+```js
+async () => {
+    await expect(promise).resolves.toBe(true);
+}
+```
+
+```js
+async () => {
+    await expect(promise).resolves.not.toBe(true);
+}
+```
+
+```js
+async () => {
+    await expect(promise).rejects.toThrow(new Error("bar"));
+}
+```
+
+```js
+async () => {
+    await expect(promise).rejects.not.toThrow(new Error("bar"));
+}
+```
+
+```js
+async () => {
+    await expect(promise).toResolve();
+}
+```
+
+```js
+async () => {
+    await expect(promise).toReject();
+}
+```

--- a/docs/sync-tag.md
+++ b/docs/sync-tag.md
@@ -7,5 +7,5 @@ sync tags and provide fixes when possible.
 Notes:
 - All paths in `ignoreFiles` are considered to be relative to `rootDir`.
 - `rootDir` is required and should usually be set to the root directory of the
-  repo.  This requires the the configuration of `khan/sync-tags` to be done in
+  repo.  This requires the the configuration of `@khanacademy/sync-tags` to be done in
   a `.js` file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ module.exports = {
         "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
         "jest-async-use-real-timers": require("./rules/jest-async-use-real-timers.js"),
+        "jest-await-async-matchers": require("./rules/jest-await-async-matchers.js"),
         "jest-enzyme-matchers": require("./rules/jest-enzyme-matchers.js"),
         "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),

--- a/lib/rules/jest-await-async-matchers.js
+++ b/lib/rules/jest-await-async-matchers.js
@@ -1,0 +1,107 @@
+const t = require("@babel/types");
+
+const getPropertyNames = node => {
+    if (!t.isMemberExpression(node)) {
+        [];
+    }
+    if (t.isIdentifier(node.property)) {
+        return [node.property.name, ...getPropertyNames(node.parent)];
+    }
+    return [];
+};
+
+const findParentCallExpression = node => {
+    if (t.isProgram(node)) {
+        return null;
+    }
+    if (t.isCallExpression(node.parent)) {
+        return node.parent;
+    }
+    return findParentCallExpression(node.parent);
+};
+
+const intersect = (array1, array2) => {
+    return array1.filter(value => array2.includes(value));
+};
+
+const getCustomMatchers = options => {
+    if (options && options[0] && options[0].matchers) {
+        return options[0].matchers;
+    }
+    return [];
+};
+
+const DEFAULT_MATCHERS = [
+    // built into jest
+    "resolves",
+    "rejects",
+    // from of jest-extended
+    "toResolve",
+    "toReject",
+];
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "",
+            category: "jest",
+            recommended: false,
+        },
+        fixable: true,
+    },
+
+    create(context) {
+        const customMatchers = getCustomMatchers(context.options);
+        const allowedMatchers = [...DEFAULT_MATCHERS, ...customMatchers];
+
+        return {
+            CallExpression(node) {
+                // We only run this check on expect() calls.
+                if (!t.isIdentifier(node.callee, {name: "expect"})) {
+                    return;
+                }
+                if (!t.isMemberExpression(node.parent)) {
+                    return;
+                }
+                // While someone could use an indexer to access matchers,
+                // that never happens in practice so we don't bother handling
+                // this edge case.
+                if (!t.isIdentifier(node.parent.property)) {
+                    return;
+                }
+
+                // Gets all the properties in a jest assertion, e.g.
+                // expect(foo).not.toEqual(bar) would result in the
+                // following property names: ["not", "toEqual"].
+                const propertyNames = getPropertyNames(node.parent);
+
+                // This should only contain a single entry when there's a match
+                const intersection = intersect(propertyNames, allowedMatchers);
+                if (intersection.length === 0) {
+                    return;
+                }
+
+                // This is the matcher call itself, e.g. .toBe(true)
+                const parentCallExpression = findParentCallExpression(node);
+                if (!parentCallExpression) {
+                    return;
+                }
+
+                if (!t.isAwaitExpression(parentCallExpression.parent)) {
+                    context.report({
+                        node: parentCallExpression,
+                        message: `Assertions using \`${intersection.join(
+                            ", ",
+                        )}\` should be awaited.`,
+                        fix(fixer) {
+                            return fixer.insertTextBefore(
+                                parentCallExpression,
+                                "await ",
+                            );
+                        },
+                    });
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/jest-enzyme-matchers.js
+++ b/lib/rules/jest-enzyme-matchers.js
@@ -5,7 +5,7 @@ module.exports = {
         docs: {
             description:
                 "Requires the use more of enzyme matchers where appropriate.",
-            category: "jes",
+            category: "jest",
             recommended: false,
         },
         fixable: true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretty-quick": "^2.0.1"
   },
   "scripts": {
-    "test": "mocha test/jest-await-async-matchers_test.js",
+    "test": "mocha test/**/*.js",
     "prettier": "prettier --write '{lib,test}/**/*.js'",
     "prepublishOnly": "npm run test"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretty-quick": "^2.0.1"
   },
   "scripts": {
-    "test": "mocha test/**/*.js",
+    "test": "mocha test/jest-await-async-matchers_test.js",
     "prettier": "prettier --write '{lib,test}/**/*.js'",
     "prepublishOnly": "npm run test"
   },

--- a/test/jest-await-async-matchers_test.js
+++ b/test/jest-await-async-matchers_test.js
@@ -1,0 +1,131 @@
+const path = require("path");
+
+const {rules} = require("../lib/index.js");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["jest-await-async-matchers"];
+
+ruleTester.run("jest-await-async-matchers", rule, {
+    valid: [
+        {
+            code: `async () => await expect(promise).resolves.toBe(true);`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).resolves.not.toBe(true);`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).rejects.toThrow("foo");`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).rejects.not.toThrow("foo");`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).toResolve();`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).not.toResolve();`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).toReject();`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(promise).not.toReject();`,
+            options: [],
+        },
+        {
+            code: `async () => await expect(callback).toHaveMarkedConversion();`,
+            options: [
+                {
+                    matchers: ["toHaveMarkedConversion"],
+                },
+            ],
+        },
+        // Don't report other matchers
+        {
+            code: `expect(callback).toBe(true);`,
+            options: [],
+        },
+    ],
+    invalid: [
+        {
+            code: `expect(promise).resolves.toBe(true);`,
+            options: [],
+            errors: ["Assertions using `resolves` should be awaited."],
+            output: "await expect(promise).resolves.toBe(true);",
+        },
+        {
+            code: `expect(promise).resolves.not.toBe(true);`,
+            options: [],
+            errors: ["Assertions using `resolves` should be awaited."],
+            output: "await expect(promise).resolves.not.toBe(true);",
+        },
+        {
+            code: `expect(promise).rejects.toThrow(new Error("foo"));`,
+            options: [],
+            errors: ["Assertions using `rejects` should be awaited."],
+            output: 'await expect(promise).rejects.toThrow(new Error("foo"));',
+        },
+        {
+            code: `expect(promise).rejects.not.toThrow(new Error("foo"));`,
+            options: [],
+            errors: ["Assertions using `rejects` should be awaited."],
+            output:
+                'await expect(promise).rejects.not.toThrow(new Error("foo"));',
+        },
+        {
+            code: `expect(promise).resolves.not.toBe(true);`,
+            options: [],
+            errors: ["Assertions using `resolves` should be awaited."],
+            output: "await expect(promise).resolves.not.toBe(true);",
+        },
+        {
+            code: `expect(promise).toResolve();`,
+            options: [],
+            errors: ["Assertions using `toResolve` should be awaited."],
+            output: "await expect(promise).toResolve();",
+        },
+        {
+            code: `expect(promise).toReject();`,
+            options: [],
+            errors: ["Assertions using `toReject` should be awaited."],
+            output: "await expect(promise).toReject();",
+        },
+        {
+            code: `expect(promise).not.toResolve();`,
+            options: [],
+            errors: ["Assertions using `toResolve` should be awaited."],
+            output: "await expect(promise).not.toResolve();",
+        },
+        {
+            code: `expect(promise).not.toReject();`,
+            options: [],
+            errors: ["Assertions using `toReject` should be awaited."],
+            output: "await expect(promise).not.toReject();",
+        },
+        // Report custom matchers if listed in the rule options
+        {
+            code: `expect(callback).toHaveMarkedConversion();`,
+            options: [
+                {
+                    matchers: ["toHaveMarkedConversion"],
+                },
+            ],
+            errors: [
+                "Assertions using `toHaveMarkedConversion` should be awaited.",
+            ],
+            output: "await expect(callback).toHaveMarkedConversion();",
+        },
+    ],
+});


### PR DESCRIPTION
## Summary:
FEI-3892 updates toHaveMarkedConversion() to be an async matcher which must be awaited.  In order to ensure that it's being used properly we need a lint rule.  This lint rule will also help to make sure we're using other async matchers like the built-in `.resolves.` and `.rejects.` as well as `.toResolve()`/`.toReject()` from jest-extended.

Issue: FEI-4164

## Test plan:
- yarn test