### PR TITLE
Add support for checksync config file

### DIFF
--- a/lib/rules/sync-tag.js
+++ b/lib/rules/sync-tag.js
@@ -3,6 +3,7 @@ const path = require("path");
 const util = require("../util.js");
 
 const PKG_ROOT = path.join(__dirname, "..", "..");
+const CHECKSYNC_PATH = path.join(PKG_ROOT, "node_modules", ".bin", "checksync");
 
 const UPDATE_REMINDER =
     "If necessary, check the sync-tag target and make relevant changes before updating the checksum.";
@@ -39,6 +40,13 @@ const processItem = (item, node, context, comments) => {
     }
 };
 
+const getCommandForFilename = ({configFile, ignoreFiles}, filename) => {
+    const ignoreFilesArg = ignoreFiles ? `--ignore-files ${ignoreFiles}` : "";
+    const configFileArg = configFile ? `--config-file ${configFile}` : "";
+
+    return `${CHECKSYNC_PATH} ${filename} ${configFileArg} ${ignoreFilesArg} --json`;
+};
+
 module.exports = {
     meta: {
         docs: {
@@ -57,6 +65,9 @@ module.exports = {
                     rootDir: {
                         type: "string",
                     },
+                    configFile: {
+                        type: "string",
+                    },
                 },
             },
         ],
@@ -64,10 +75,11 @@ module.exports = {
     },
 
     create(context) {
+        const configFile = context.options[0].configFile;
         const ignoreFiles = (context.options[0].ignoreFiles || []).join(",");
         const rootDir = context.options[0].rootDir;
         if (!rootDir) {
-            throw new Error("rootDir must be set");
+            throw new Error("rootDir must be set and exist");
         }
 
         return {
@@ -83,14 +95,11 @@ module.exports = {
                         rootDir,
                         context.getFilename(),
                     );
-                    const checksyncPath = path.join(
-                        PKG_ROOT,
-                        "node_modules",
-                        ".bin",
-                        "checksync",
-                    );
 
-                    const command = `${checksyncPath} ${filename} -c "//,#,{/*,{{/*" -m .ka_root --ignore-files ${ignoreFiles} --json`;
+                    const command = getCommandForFilename(
+                        {configFile, ignoreFiles},
+                        filename,
+                    );
                     const stdout = util.execSync(command, {
                         cwd: rootDir,
                         encoding: "utf-8",

--- a/lib/rules/sync-tag.js
+++ b/lib/rules/sync-tag.js
@@ -40,9 +40,14 @@ const processItem = (item, node, context, comments) => {
     }
 };
 
-const getCommandForFilename = ({configFile, ignoreFiles}, filename) => {
+const getCommandForFilename = (
+    {configFile, ignoreFiles, rootDir},
+    filename,
+) => {
     const ignoreFilesArg = ignoreFiles ? `--ignore-files ${ignoreFiles}` : "";
-    const configFileArg = configFile ? `--config-file ${configFile}` : "";
+    const configFileArg = configFile
+        ? `--config-file ${path.join(rootDir, configFile)}`
+        : "";
 
     return `${CHECKSYNC_PATH} ${filename} ${configFileArg} ${ignoreFilesArg} --json`;
 };
@@ -79,7 +84,7 @@ module.exports = {
         const ignoreFiles = (context.options[0].ignoreFiles || []).join(",");
         const rootDir = context.options[0].rootDir;
         if (!rootDir) {
-            throw new Error("rootDir must be set and exist");
+            throw new Error("rootDir must be set");
         }
 
         return {
@@ -97,7 +102,7 @@ module.exports = {
                     );
 
                     const command = getCommandForFilename(
-                        {configFile, ignoreFiles},
+                        {configFile, ignoreFiles, rootDir},
                         filename,
                     );
                     const stdout = util.execSync(command, {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@babel/types": "^7.7.4",
-    "checksync": "^2.3.0"
+    "checksync": "^4.0.0"
   },
   "husky": {
     "hooks": {

--- a/test/sync-tag_test.js
+++ b/test/sync-tag_test.js
@@ -39,7 +39,7 @@ util.execSync = command => {
     return "";
 };
 
-ruleTester.run("require-static-url", rule, {
+ruleTester.run("sync-tag", rule, {
     valid: [
         {
             code:
@@ -47,6 +47,18 @@ ruleTester.run("require-static-url", rule, {
             filename: "filea",
             options: [
                 {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+        {
+            code:
+                "// sync-start:foo-bar 1424803960 fileb\nconst FooBar = 'foobar';\n// sync-end:foobar",
+            filename: "filea",
+            options: [
+                {
+                    configFile: "./checksync.json",
                     ignoreFiles: ["lint_blacklist.txt"],
                     rootDir: "/Users/nyancat/project",
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,10 +263,10 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
-checksync@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/checksync/-/checksync-2.3.0.tgz#d0801971aaa84a0adbc33734d1dab18f87ed54bd"
-  integrity sha512-QhR8MfvqAjo574gILPhGa1+j2NCyhhBC9biY1jigaPOnrtCO23QO+U+4cGfsw0IINXJd3yk6kcNtRKs5JYCdpg==
+checksync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/checksync/-/checksync-4.0.0.tgz#fd74959cc91f665047ae94b541ab22007b0a9b53"
+  integrity sha512-G+wpCe4LfFLUSLCD+cSwF/stWXP9tm4M2Iy+8CBKiBX0izZ53nHTzbQ02aKfVxg6Q87e1xd/Q7AJbPXqiQxacw==
 
 ci-info@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary:
This makes a few tweaks to the sync-tag rule and updates the version of checksync being used. Should be a major release since this changes what versions of Node are supported.

Issue: FEI-4821

## Test plan:
`yarn test`

I'm also going to put up the webapp PR with the commit SHA of this PR to test it there.