### PR TITLE
[🔥AUDIT🔥] Handle checksync exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ eslint plugin with our set of custom rules for various things
 - [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)
 - [khan/react-svg-path-precision](docs/react-svg-path-precision.md)
+- [khan/sync-tag](docs/sync-tag.md)

--- a/lib/rules/sync-tag.js
+++ b/lib/rules/sync-tag.js
@@ -75,6 +75,27 @@ const getCommandForFilename = (
     return `${CHECKSYNC_PATH} ${filename} ${configFileArg} ${ignoreFilesArg} --json`;
 };
 
+const getSyncErrors = ({configFile, ignoreFiles, rootDir}, filename) => {
+    const command = getCommandForFilename(
+        {configFile, ignoreFiles, rootDir},
+        filename,
+    );
+    try {
+        return util.execSync(command, {
+            cwd: rootDir,
+            encoding: "utf-8",
+        });
+    } catch (e) {
+        // From https://github.com/somewhatabstract/checksync/blob/b2f31732715aa940051e7b2b2166b4699aa0f047/src/exit-codes.js
+        // Error 3 is that we have DESYNCHRONIZED_BLOCKS.
+        if (e.status === 3) {
+            return e.stdout;
+        }
+
+        throw e;
+    }
+};
+
 module.exports = {
     meta: {
         docs: {
@@ -124,17 +145,13 @@ module.exports = {
                         context.getFilename(),
                     );
 
-                    const command = getCommandForFilename(
+                    const rawJson = getSyncErrors(
                         {configFile, ignoreFiles, rootDir},
                         filename,
                     );
-                    const stdout = util.execSync(command, {
-                        cwd: rootDir,
-                        encoding: "utf-8",
-                    });
 
                     try {
-                        const data = JSON.parse(stdout);
+                        const data = JSON.parse(rawJson);
                         const fileOutput = Object.keys(data.files).find(f =>
                             filename.endsWith(f),
                         );

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "name": "@khanacademy/eslint-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publishConfig": {
     "access": "public"
   },
   "files": [
-    "/lib",
-    "/node_modules/checksync/bin",
-    "/node_modules/checksync/dist"
+    "/lib"
   ],
   "main": "lib/index.js",
   "repository": "https://github.com/Khan/eslint-plugin-khan",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Checksync has more illustrative exit codes since v3 and since when there are errors, it's non-zero, eslint assumes failure.

This updates the plugin to handle that more elegantly and give us a clearer clue as to the issue.

Issue: FEI-4821

## Test plan:
`yarn test`

Also ran this to check the output.